### PR TITLE
Add option to use GitHub tags instead of markdown links

### DIFF
--- a/pygcgen/generator.py
+++ b/pygcgen/generator.py
@@ -367,6 +367,7 @@ class Generator:
         Parse issue and generate single line formatted issue line.
         Example output:
         - Add coveralls integration [\#223](https://github.com/skywinder/github-changelog-generator/pull/223) ([skywinder](https://github.com/skywinder))
+        - Add coveralls integration [\#223](https://github.com/skywinder/github-changelog-generator/pull/223) (@skywinder)
 
         @param [Hash] issue Fetched issue from GitHub
         @return [String] Markdown-formatted single issue
@@ -382,16 +383,23 @@ class Generator:
             print(issue["number"])
             print(issue["html_url"])
             title_with_number = "ERROR ERROR ERROR"
+        return self.issue_line_with_user(title_with_number, issue)
 
-        if issue.get("pull_request"):
-            if self.options.author:
-                if not issue.get("user"):
-                    title_with_number += u" (Null user)"
-                else:
-                    title_with_number += u" ([{0}]({1}))".format(
-                        issue["user"]["login"], issue["user"]["html_url"]
-                    )
-        return title_with_number
+    def issue_line_with_user(self, line, issue):
+        if not issue.get("pull_request") or not self.options.author:
+            return line
+
+        if not issue.get("user"):
+            line += u" (Null user)"
+        elif self.options.username_as_tag:
+            line += u" (@{0})".format(
+                issue["user"]["login"]
+            )
+        else:
+            line += u" ([{0}]({1}))".format(
+                issue["user"]["login"], issue["user"]["html_url"]
+            )
+        return line
 
     def create_log_for_tag(self, pull_requests, issues,
                            newer_tag, older_tag_name=None):

--- a/pygcgen/generator.py
+++ b/pygcgen/generator.py
@@ -105,7 +105,7 @@ class Generator:
             self.find_closed_date_by_commit(issue)
             if not issue.get('actual_date', False):
                 # TODO: don't remove it ???
-                print("\nHELP ME! is it correct to remove #{0} {1}".format(issue["number"], issue["title"]))
+                print("\nHELP ME! is it correct to skip #{0} {1}".format(issue["number"], issue["title"]))
                 issues.remove(issue)
 
         if self.options.verbose:

--- a/pygcgen/options_parser.py
+++ b/pygcgen/options_parser.py
@@ -293,13 +293,17 @@ class OptionsParser:
         if os.path.exists(opts.options_file):
             OptionsFileParser(options=opts).parse()
         if not opts.user or not opts.project:
-            self.user_and_project_from_git(opts)
+            self.fetch_user_and_project(opts)
         return opts
 
-    def user_and_project_from_git(self, options):
-        options.user, options.project = self.detect_user_and_project(options)
+    def fetch_user_and_project(self, options):
+        user, project = self.user_and_project_from_git(options)
+        if not options.user:
+            options.user = user
+        if not options.project:
+            options.project = project
 
-    def detect_user_and_project(self, options, arg0=None, arg1=None):
+    def user_and_project_from_git(self, options, arg0=None, arg1=None):
         ''' Detects user and project from git. '''
         user, project = self.user_project_from_option(options, arg0, arg1)
         if user and project:

--- a/pygcgen/options_parser.py
+++ b/pygcgen/options_parser.py
@@ -154,6 +154,12 @@ class OptionsParser:
             help="Don't add author of pull-request in the end."
         )
         parser.add_argument(
+            "--usernames-as-github-logins",
+            action='store_true', dest="username_as_tag",
+            help="Use GitHub tags instead of Markdown links for the "
+                 "author of an issue or pull-request."
+        )
+        parser.add_argument(
             "--with-unreleased",
             action='store_true', dest="with_unreleased",
             help="Include unreleased closed issues in log."

--- a/pygcgen/optionsfile_parser.py
+++ b/pygcgen/optionsfile_parser.py
@@ -4,44 +4,46 @@
 FILENAME = ".pygcgen"
 KNOWN_INTEGER_KEYS = ["max_issues"]
 KNOWN_ARRAY_KEYS = [ # TODO: umbauen auf dict(key: cnt) # cnt=Anzahl:-1=egal
-    "exclude_labels",
-    "include_labels",
+    "between_tags",
     "bug_labels",
     "enhancement_labels",
-    "between_tags",
+    "exclude_labels",
     "exclude_tags"
+    "include_labels",
 ]
 IRREGULAR_OPTIONS = {
     "bugs_label": "bug_prefix",
     "enhancement_label": "enhancement_prefix",
-    "issues_label": "issue_prefix",
-    "header_label": "header",
     "front_matter": "frontmatter",
-    "pr_label": "merge_prefix",
+    "github_api": "github_endpoint",
+    "header_label": "header",
+    "issues_label": "issue_prefix",
+    "no_author": "author",
+    "no_compare_link": "compare_link",
+    "no_filter_by_milestone": "filter_issues_by_milestone",
     "no_issues": "issues",
     "no_issues_wo_labels": "add_issues_wo_labels",
     "no_pr_wo_labels": "add_pr_wo_labels",
     "no_pull_requests": "include_pull_request",
-    "no_filter_by_milestone": "filter_issues_by_milestone",
-    "no_author": "author",
-    "no_compare_link": "compare_link",
-    "github_api": "github_endpoint",
-    "origin": "git_remote"
+    "origin": "git_remote",
+    "pr_label": "merge_prefix",
+    "usernames_as_github_logins": "username_as_tag",
 }
 BOOL_KEYS = {
+    "debug": True,
+    "no_author": False,
+    "no_compare_link": False,
+    "no_filter_by_milestone": False,
     "no_issues": False,
     "no_issues_wo_labels": False,
     "no_pr_wo_labels": False,
     "no_pull_requests": False,
-    "no_filter_by_milestone": False,
-    "no_author": False,
-    "no_compare_link": False,
-    "with_unreleased": True,
+    "simple_list": True,
     "unreleased_only": True,
     "unreleased_with_date": True,
-    "simple_list": True,
+    "username_as_tag": False,
     "verbose": True,
-    "debug": True,
+    "with_unreleased": True,
 }
 
 


### PR DESCRIPTION
- Add option to use GitHub tags instead of markdown links
- adopt some changes from skywinder/github-changelog-generator
