### PR TITLE
Skip non-merged closed issues?

### DIFF
--- a/pygcgen/generator.py
+++ b/pygcgen/generator.py
@@ -131,13 +131,13 @@ class Generator(object):
                 if not issues.index(issue) % 30:
                     print("")
             self.find_closed_date_by_commit(issue)
+
             if not issue.get('actual_date', False):
-                # TODO: don't remove it ???
-                if not self.options.quiet:
-                    print("HELP ME! is it correct to skip #{0} {1}?".format(
-                        issue["number"], issue["title"])
-                    )
-                issues.remove(issue)
+                if issue.get('closed_at', False):
+                    print("Skipping closed non-merged issue: #{0} {1}".format(
+                        issue["number"], issue["title"]))
+
+                all_issues.remove(issue)
 
         if self.options.verbose > 2:
             print(".")


### PR DESCRIPTION
We just got one of issues like that mentioned in `HELP`. It appears to be closed non-merged issue.

Anyway, line `140 issues.remove(issue)` should say `all_issues.remove(issue)`, so that it works on copy, otherwise it fails with exception trying to remove the item from `all_issues`.